### PR TITLE
Add sanity check in GauXC interface

### DIFF
--- a/src/dft/gauxcutils.cxx
+++ b/src/dft/gauxcutils.cxx
@@ -107,6 +107,8 @@ GauXC::BasisSet<double> GauXCUtils::make_gbasis(const BasisSet& basis) {
   GauXC::Shell<double>::cart_array gauxc_cart_arr;
 
   for(const auto& shell : basis.shells) {
+    if(shell.nprim() > GauXC::detail::shell_nprim_max)
+      throw std::runtime_error("Shell has " << shell.nprim() << " primitives but the shell datatype in GauXC is limited to " << GauXC::detail::shell_nprim_max << "!\nTo work around this issue, segment your basis set!\n");
     for (auto a1 = 0; a1 < shell.nprim(); a1++) {
       gauxc_alpha_arr[a1] = shell.alpha[a1];
       gauxc_coeff_arr[a1] = shell.contr[0].coeff[a1];


### PR DESCRIPTION
We started going through the GauXC interface, looking at the ChronusQ interface as an example.
I noted that a sanity check was missing for the number of exponents, which may result in an array overflow.
This PR adds that missing sanity check.